### PR TITLE
Fix: Fix backspace number formatting

### DIFF
--- a/StickyCalculator/Sources/ViewControllers/MainViewReactor.swift
+++ b/StickyCalculator/Sources/ViewControllers/MainViewReactor.swift
@@ -141,7 +141,7 @@ class MainViewReactor: Reactor {
                 state.resultValue.clear(with: "0")
             } else {
                 let backspacedResult = state.resultValue.description.dropLast().description
-                state.resultValue = backspacedResult.description
+                state.resultValue = backspacedResult.toFormattedNumber(with: numberFormatter)
             }
             
         case .updateResultPrefix:


### PR DESCRIPTION
Now result label shows 1,988 not 19,88 when press the backspace button from 19,888

Ref: #9